### PR TITLE
Fixar en bugg där man inte kunde logga in i admingränssnittet.

### DIFF
--- a/scouterna/functions.php
+++ b/scouterna/functions.php
@@ -477,8 +477,8 @@ function adjust_the_wp_menu() {
 }
 add_action( 'after_setup_theme','remove_twentyeleven_options', 100 );
 function remove_twentyeleven_options() {	
-	if( function_exists( 'remove_custom_image_header' ) ) {
-		remove_custom_image_header();		
+	if( function_exists( remove_theme_support( 'custom-header' )  ) ) {
+		remove_theme_support( 'custom-header' ) ;		
 	} else {
 		remove_theme_support( 'custom-header' );
 	}


### PR DESCRIPTION
Symptom:

Vid inloggning visas ett felmeddelande om att webbläsaren inte accepterar
cookies, samt debugmeddelanden nedan.

Orsak:

Enligt debugmeddelanden:
 – Notice: remove_custom_image_header is deprecated since version 3.4!
   Use removec_theme_support( 'custom-header' ) instead.
   in /srv/www/scouterna/wp-includes/functions.php on line 2919
 – Warning: Cannot modify header information - headers already sent by (output
   started at /srv/www/scouterna/wp-includes/functions.php:2919) in
   /srv/www/scouterna/wp-login.php on line 293

Miljö:

Testad i Wordpress 3.7-beta1-25639
